### PR TITLE
OBS-1412 Gotcha! Do not capitalize mail.enabled when templating openboxes-config.groovy

### DIFF
--- a/ansible/templates/openboxes-config.groovy.j2
+++ b/ansible/templates/openboxes-config.groovy.j2
@@ -23,7 +23,7 @@ grails.app.context = "{{ app_context }}"
 // MailService.groovy
 {% if mail_enabled is defined %}
 grails.mail.bcc = "{{ mail_bcc }}"
-grails.mail.enabled = {{ mail_enabled }}
+grails.mail.enabled = {{ mail_enabled | string | lower }}
 grails.mail.from = "{{ mail_address }}"
 grails.mail.host = "{{ mail_host }}"
 grails.mail.password = "{{ mail_password }}"


### PR DESCRIPTION
Ansible's template language is jinja2, which is Python-based, where Booleans are Capitalized. This can cause problems when writing to a groovy file, where booleans are lower-cased.