### PR TITLE
OBS-1424 Configure database connection without making JDBC URLs unwieldy

### DIFF
--- a/ansible/templates/openboxes-config.groovy.j2
+++ b/ansible/templates/openboxes-config.groovy.j2
@@ -3,6 +3,19 @@
 
 dataSource {
     password = "{{ db_users.openboxes.password }}"
+    properties = {
+        autoReconnectForPools = true
+        autoSlowLog = {{ 'dev' in group_names or 'stg' in group_names | string | lower }}
+        dumpQueriesOnException = true
+        explainSlowQueries = {{ 'dev' in group_names or 'stg' in group_names | string | lower }}
+        includeInnodbStatusInDeadlockExceptions = true
+        includeThreadDumpInDeadlockExceptions = true
+        includeThreadNamesAsStatementComment = true
+        logSlowQueries = {{ 'dev' in group_names or 'stg' in group_names | string | lower }}
+        requireSSL = true
+        useSSL = true
+        verifyServerCertificate = true
+    }
     {% if db_url is defined %}
     url = "{{ db_url }}"
     {% endif %}


### PR DESCRIPTION
This PR allows sysadmins to specify a URL like `jdbc:mysql://localhost:3306/openboxes` when configuring an OB install without having to remember that we like to set e.g. `dumpQueriesOnException` to ease debugging.

The same approach used here will allow us to specify character encoding and collating, again, without requiring sites to care about various utf-8 flavors