### PR TITLE
OBPIH-5476 Bump nginx timeouts from 6 min to 20 min

### DIFF
--- a/ansible/templates/default.conf.j2
+++ b/ansible/templates/default.conf.j2
@@ -52,10 +52,10 @@ server {
       text/plain
       text/xml;
 
-    # default timeout of 1 minute can return 504's when reports are slow (OBS-1396)
-    proxy_connect_timeout 360;
-    proxy_read_timeout 360;
-    proxy_send_timeout 360;
+    # default timeout of 1 minute can return 504's when reports are slow (OBS-1396, OBPIH-5476)
+    proxy_connect_timeout 1200;
+    proxy_read_timeout 1200;
+    proxy_send_timeout 1200;
 
     resolver 1.1.1.1;
     server_name {{ ansible_fqdn }};


### PR DESCRIPTION
See https://pihemr.atlassian.net/browse/OBPIH-5476?focusedCommentId=141431