### PR TITLE
Improve bamboo remote agent setup

### DIFF
--- a/ansible/inventories/pih_rimu.yml
+++ b/ansible/inventories/pih_rimu.yml
@@ -10,7 +10,6 @@ all:
           - 3735553
         remote_agent_home: /home/bamboo/remote-agent
         server_url: https://bamboo-ci.pih-emr.org
-        server_version: 9.2.1
       db_name: openboxes
       mail:
         admins:
@@ -176,6 +175,8 @@ all:
               name: tomcat85
     bamboo_remote_agents:
       hosts:
+        obdev1:
+        obdev2:
         obdev3:
         obdev4:
     dev:

--- a/ansible/playbooks/install_bamboo_remote_agent.yml
+++ b/ansible/playbooks/install_bamboo_remote_agent.yml
@@ -40,8 +40,8 @@
       register: disable_agents
       ansible.builtin.script:
         cmd: >
-          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }}
-          -u {{ vault.bamboo.username }} {{ inventory.bamboo.server_url }} disable
+          ../scripts/disable_remote_agents.bash -p {{ ansible_fqdn }}
+          -u {{ vault.bamboo.username }} {{ inventory.bamboo.server_url }}
       environment:
         BAMBOO_PASSWORD: "{{ vault.bamboo.password }}"
 
@@ -138,6 +138,22 @@
         owner: bamboo
         src: /var/log/bamboo-remote-agent
         state: link
+
+    - name: Configuring bamboo agent log rotation
+      ansible.builtin.template:
+        dest: /etc/logrotate.d/bamboo-remote-agent
+        group: root
+        mode: '0444'
+        owner: root
+        src: ../templates/bamboo-remote-agent.logrotate.j2
+
+    #
+    # A few downstream steps check logs. Rotating them before they do so
+    # prevents them from seeing dead agents' messages as signs of life.
+    #
+    - name: Rotating bamboo agent logs
+      ansible.builtin.command:
+        cmd: logrotate --force /etc/logrotate.d/bamboo-remote-agent
 
     - name: Touching toplevel bamboo log file
       ansible.builtin.file:
@@ -318,25 +334,52 @@
         name: bamboo-remote-agent
         state: restarted
 
-    - name: Waiting for remote agent to fully connect
+    - name: Waiting for remote agent to start logging
+      register: remote_agent_logfile
+      ansible.builtin.stat:
+        path: /var/log/bamboo-remote-agent/atlassian-bamboo.log
+      delay: 1
+      retries: 60
+      until: remote_agent_logfile.stat.get('size', 0) > 0
+
+    - name: Waiting for remote agent to check build queue
+      register: remote_agent_id_regex
       ansible.builtin.wait_for:
-        path: "{{ inventory.bamboo.remote_agent_home }}/logs/atlassian-bamboo.log"
-        search_regex: 'ready to receive builds'
+        path: /var/log/bamboo-remote-agent/atlassian-bamboo.log
+        search_regex: 'Agent (\d+) checking build queue for executables'
 
-    - name: Attaching agent to projects
-      register: attach_agents
-      when: inventory.get('bamboo', {}).get('project_ids')
-      ansible.builtin.script:
-        cmd: >
-          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }}
-          -u {{ vault.bamboo.username }} {{ inventory.bamboo.server_url }} {{ item }}
-      environment:
-        BAMBOO_PASSWORD: "{{ vault.bamboo.password }}"
-      loop: "{{ inventory.bamboo.project_ids }}"
-
-    - name: Collecting script output
-      when: attach_agents.stdout_lines is defined
+    - name: Collecting remote agent id
       ansible.builtin.debug:
         msg:
-          - "{{ attach_agents.stdout_lines }}"
-          - "{{ attach_agents.stderr_lines }}"
+          - "{{ remote_agent_id_regex.match_groups[0] }}"
+
+    - name: Waiting for bamboo server to acknowledge remote agent
+      register: agent_status
+      ansible.builtin.shell:
+        cmd: >
+          curl -H 'Accept: application/json' -X GET
+          -su "{{ vault.bamboo.username }}:{{ vault.bamboo.password }}"
+          {{ inventory.bamboo.server_url }}/rest/api/latest/agent/{{ remote_agent_id_regex.match_groups[0] }}/status
+          | jq -r '.online'
+      delay: 10
+      retries: 6
+      until: agent_status.stdout.find('true') != -1
+
+    - name: Dedicating agent to projects
+      register: dedicate_agent
+      when: inventory.get('bamboo', {}).get('project_ids')
+      ansible.builtin.shell:
+        cmd: >
+          query_string='assignmentType=PROJECT';
+          query_string="${query_string}&entityId={{ item }}";
+          query_string="${query_string}&executorId={{ remote_agent_id_regex.match_groups[0] }}";
+          query_string="${query_string}&executorType=AGENT";
+          curl -H 'Accept: application/json' -X POST
+          -su "{{ vault.bamboo.username }}:{{ vault.bamboo.password }}"
+          "{{ inventory.bamboo.server_url }}/rest/api/latest/agent/assignment?${query_string}"
+      loop: "{{ inventory.bamboo.project_ids }}"
+      until: remote_agent_id_regex.match_groups[0] in dedicate_agent.stdout
+
+    - name: Collecting curl output
+      ansible.builtin.debug:
+        msg: "{% for r in dedicate_agent.results %}{{ r.stdout }}{% endfor %}"

--- a/ansible/playbooks/install_bamboo_remote_agent.yml
+++ b/ansible/playbooks/install_bamboo_remote_agent.yml
@@ -21,11 +21,26 @@
           - "{{ apt_install.stdout_lines }}"
           - "{{ apt_install.stderr_lines }}"
 
+    - name: Getting bamboo server version
+      register: server_version
+      ansible.builtin.shell:
+        cmd: >
+          curl -H 'Accept: application/json' -X GET
+          -su "{{ vault.bamboo.username }}:{{ vault.bamboo.password }}"
+          {{ inventory.bamboo.server_url }}/rest/api/latest/info
+          | jq -r '.version'
+
+    - name: Collecting bamboo server version
+      when: server_version.stdout_lines is defined
+      ansible.builtin.debug:
+        msg:
+          - "{{ server_version.stdout }}"
+
     - name: Disabling agents associated with host
       register: disable_agents
       ansible.builtin.script:
-        cmd: |
-          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }} \
+        cmd: >
+          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }}
           -u {{ vault.bamboo.username }} {{ inventory.bamboo.server_url }} disable
       environment:
         BAMBOO_PASSWORD: "{{ vault.bamboo.password }}"
@@ -91,8 +106,8 @@
         mode: '0400'
         owner: bamboo
         timeout: 30
-        # to find this URL, point a browser to {{ inventory.bamboo.server_url }}/admin/agent/addRemoteAgent.action
-        url: "{{ inventory.bamboo.server_url }}/agentServer/agentInstaller/atlassian-bamboo-agent-installer-{{ inventory.bamboo.server_version }}.jar"
+        # to find this URL, point a browser to {{ server_version.stdout }}/admin/agent/addRemoteAgent.action
+        url: "{{ inventory.bamboo.server_url }}/agentServer/agentInstaller/atlassian-bamboo-agent-installer-{{ server_version.stdout }}.jar"
 
     - name: Installing bamboo remote agent
       become: true
@@ -312,8 +327,8 @@
       register: attach_agents
       when: inventory.get('bamboo', {}).get('project_ids')
       ansible.builtin.script:
-        cmd: |
-          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }} \
+        cmd: >
+          ../scripts/configure_remote_agents.bash -p {{ ansible_fqdn }}
           -u {{ vault.bamboo.username }} {{ inventory.bamboo.server_url }} {{ item }}
       environment:
         BAMBOO_PASSWORD: "{{ vault.bamboo.password }}"

--- a/ansible/templates/bamboo-remote-agent.logrotate.j2
+++ b/ansible/templates/bamboo-remote-agent.logrotate.j2
@@ -1,0 +1,10 @@
+# Ansible generated this file from {{ template_path }}; do not edit locally!
+{# If this comment is present, this is the template file: disregard this warning #}
+
+/var/log/bamboo-remote-agent/*.log {
+    compress
+    copytruncate
+    missingok
+    rotate 90
+    weekly
+}


### PR DESCRIPTION
This PR adds obdev1 and obdev2 to the remote agent pool, and fixes a few bugs that could cause Ansible to not successfully dedicate a new agent, and not notice.