### PR TITLE
OBPIH-5618 Handle split hosts and finance user in {reset,restore}_db.yml

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -66,6 +66,21 @@ $ ansible-playbook -e @secrets/vault_rimu -i inventories/pih_rimu.yml playbooks/
 $ ansible-playbook -e @secrets/vault_rimu -i inventories/pih_rimu.yml dba/reset_db.yml -l obdev1
 ```
 
+## Example 3: Use playbooks to copy the production database to the staging instance
+
+```
+# Extract database data from the production instance in Azure
+$ ansible-playbook -e @secrets/vault_azure -i inventories/pih_azure.yml dba/archive_db.yml -l obnav
+
+#
+# Upload that database data to the stg instance.
+#
+# Note the build target in this case is a group, not a host. This playbook not
+# only needs to replace the database on dbstg, but also restart tomcat on obstg.
+#
+$ ansible-playbook -e @secrets/vault_rimu -i inventories/pih_rimu.yml dba/restore_db.yml -l stg -e 'force=true'
+```
+
 ## Exceptions to the rule
 
 Legacy hosts aren't configured as consistently as those in RIMU. A few things to

--- a/ansible/dba/archive_db.yml
+++ b/ansible/dba/archive_db.yml
@@ -1,5 +1,5 @@
 - name: Archiving OpenBoxes database (please allow 5-10 minutes)
-  hosts: all
+  hosts: dbservers
   vars:
     archive_file: openboxes.tgz
     db_username: openboxes

--- a/ansible/dba/reset_db.yml
+++ b/ansible/dba/reset_db.yml
@@ -1,4 +1,5 @@
-- name: Resetting OpenBoxes database (please allow 15-20 minutes)
+- name: Resetting OpenBoxes database (please allow an hour or so)
+  any_errors_fatal: true
   hosts: all:!prd
   vars:
     db_username: openboxes
@@ -17,45 +18,55 @@
         name: tomcat
         state: stopped
 
-    - name: Clobbering mysql database
-      register: reset_db
-      ansible.builtin.script:
-        cmd: |
-          ../scripts/reset_db.bash \
-          {{ '-s' if use_sudo else '' }} -d {{ inventory.db_name }} -u {{ db_username }}
-      environment:
-        DB_ROOT_PASSWORD: "{{ vault.db_users.root.password }}"
-        DB_USER_PASSWORD: "{{ vault.db_users[db_username].password }}"
-
-    - name: Collecting script output
-      when: reset_db.stdout_lines is defined
-      ansible.builtin.debug:
-        msg:
-          - "{{ reset_db.stdout_lines \
-              | regex_replace(vault.db_users.root.password, '********') \
-              | regex_replace(vault.db_users[db_username].password, '********') }}"
-          - "{{ reset_db.stderr_lines \
-              | regex_replace(vault.db_users.root.password, '********') \
-              | regex_replace(vault.db_users[db_username].password, '********') }}"
-
-    - name: Restarting MariaDB service
-      ansible.builtin.systemd:
-        daemon_reload: true
-        name: mysql
-        state: restarted
-
-    - name: Restarting and verifying Tomcat on web-serving hosts
-      when: inventory.get('tomcat', {}).get('enabled')
+    - name: Resetting database
+      when: inventory.get('mysql', {}).get('enabled')
       block:
-        - name: Restarting Tomcat service on web-serving hosts
+
+        - name: Clobbering mysql database
+          register: reset_db
+          ansible.builtin.script:
+            cmd: >
+              ../scripts/reset_db.bash
+              {{ '-s' if use_sudo else '' }}
+              -c {{ inventory.get('remote_webserver', 'localhost') }}
+              -d {{ inventory.db_name }}
+              -u {{ db_username }}
+          environment:
+            DB_ROOT_PASSWORD: "{{ vault.db_users.root.password }}"
+            DB_USER_PASSWORD: "{{ vault.db_users[db_username].password }}"
+
+        - name: Collecting script output
+          when: reset_db.stdout_lines is defined
+          ansible.builtin.debug:
+            msg:
+              - "{{ reset_db.stdout_lines \
+                  | regex_replace(vault.db_users.root.password, '********') \
+                  | regex_replace(vault.db_users[db_username].password, '********') }}"
+              - "{{ reset_db.stderr_lines \
+                  | regex_replace(vault.db_users.root.password, '********') \
+                  | regex_replace(vault.db_users[db_username].password, '********') }}"
+
+        - name: Restarting MariaDB service
           ansible.builtin.systemd:
             daemon_reload: true
-            name: tomcat
+            name: mysql
             state: restarted
-        - name: "Waiting for 200 from https://...{{ inventory.app_context }}"
-          delay: 15
-          retries: 60
-          register: https_response
-          until: https_response.status == 200
-          ansible.builtin.uri:
-            url: "https://{{ ansible_fqdn }}{{ inventory.app_context }}"
+
+    - name: Restarting Tomcat service on web-serving hosts
+      when: inventory.get('tomcat', {}).get('enabled')
+      ansible.builtin.systemd:
+        daemon_reload: true
+        name: tomcat
+        state: restarted
+
+    - name: "Waiting for 200 from https://...{{ inventory.app_context }}"
+      delay: 30
+      retries: 180  # # migrations can take a very long time starting from scratch
+      register: https_response
+      until: https_response.status == 200
+      ansible.builtin.uri:
+        url: "https://{{ inventory.get('remote_webserver', ansible_fqdn) }}{{ inventory.app_context }}"
+        validate_certs: false
+
+- name: Re-enabling PIH user access
+  ansible.builtin.import_playbook: ../playbooks/enable_pih_user_access.yml

--- a/ansible/dba/restore_db.yml
+++ b/ansible/dba/restore_db.yml
@@ -1,4 +1,5 @@
 - name: Restoring OpenBoxes database (please allow 10-30+ minutes)
+  any_errors_fatal: true
   hosts: all:!prd
   vars:
     archive_file: ../build/archive_db/obnav/openboxes.tgz
@@ -19,55 +20,66 @@
         name: tomcat
         state: stopped
 
-    - name: Uploading archive to remote host (this can be slow)
-      ansible.builtin.copy:
-        dest: "{{ archive_file | basename }}"
-        group: root
-        mode: '0400'
-        owner: root
-        src: "{{ archive_file }}"
-
-    - name: Importing mysql archive (this can be slow, too)
-      register: restore_db
-      ansible.builtin.script:
-        cmd: |
-          ../scripts/restore_db.bash \
-          {{ '-f' if force else '' }} {{ '-s' if use_sudo else '' }} \
-          -d {{ inventory.db_name }} -i {{ archive_file | basename }} -u {{ db_username }}
-      environment:
-        DB_ROOT_PASSWORD: "{{ vault.db_users.root.password }}"
-        DB_USER_PASSWORD: "{{ vault.db_users[db_username].password }}"
-
-    - name: Collecting script output
-      when: restore_db.stdout_lines is defined
-      ansible.builtin.debug:
-        msg:
-          - "{{ restore_db.stdout_lines | regex_replace(vault.db_users[db_username].password, '********') }}"
-          - "{{ restore_db.stderr_lines | regex_replace(vault.db_users[db_username].password, '********') }}"
-
-    - name: Deleting archive file from remote host after loading
-      ansible.builtin.file:
-        path: "{{ archive_file | basename }}"
-        state: absent
-
-    - name: Restarting MariaDB service
-      ansible.builtin.systemd:
-        daemon_reload: true
-        name: mysql
-        state: restarted
-
-    - name: Restarting and verifying Tomcat on web-serving hosts
-      when: inventory.get('tomcat', {}).get('enabled')
+    - name: Restoring database
+      when: inventory.get('mysql', {}).get('enabled')
       block:
-        - name: Restarting Tomcat service on web-serving hosts
+
+        - name: Uploading archive to remote host (this can be slow)
+          ansible.builtin.copy:
+            dest: "{{ archive_file | basename }}"
+            group: root
+            mode: '0400'
+            owner: root
+            src: "{{ archive_file }}"
+
+        - name: Importing mysql archive (this can be slow, too)
+          register: restore_db
+          ansible.builtin.script:
+            cmd: >
+              ../scripts/restore_db.bash
+              {{ '-f' if force else '' }}
+              {{ '-s' if use_sudo else '' }}
+              -c {{ inventory.get('remote_webserver', 'localhost') }}
+              -d {{ inventory.db_name }}
+              -i {{ archive_file | basename }}
+              -u {{ db_username }}
+          environment:
+            DB_ROOT_PASSWORD: "{{ vault.db_users.root.password }}"
+            DB_USER_PASSWORD: "{{ vault.db_users[db_username].password }}"
+
+        - name: Collecting script output
+          when: restore_db.stdout_lines is defined
+          ansible.builtin.debug:
+            msg:
+              - "{{ restore_db.stdout_lines | regex_replace(vault.db_users[db_username].password, '********') }}"
+              - "{{ restore_db.stderr_lines | regex_replace(vault.db_users[db_username].password, '********') }}"
+
+        - name: Deleting archive file from remote host after loading
+          ansible.builtin.file:
+            path: "{{ archive_file | basename }}"
+            state: absent
+
+        - name: Restarting MariaDB service
           ansible.builtin.systemd:
             daemon_reload: true
-            name: tomcat
+            name: mysql
             state: restarted
-        - name: "Waiting for 200 from https://...{{ inventory.app_context }}"
-          delay: 15
-          retries: 60
-          register: https_response
-          until: https_response.status == 200
-          ansible.builtin.uri:
-            url: "https://{{ ansible_fqdn }}{{ inventory.app_context }}"
+
+    - name: Restarting Tomcat service on web-serving hosts
+      when: inventory.get('tomcat', {}).get('enabled')
+      ansible.builtin.systemd:
+        daemon_reload: true
+        name: tomcat
+        state: restarted
+
+    - name: "Waiting for 200 from https://...{{ inventory.app_context }}"
+      delay: 30
+      retries: 90  # migrations can take a while
+      register: https_response
+      until: https_response.status == 200
+      ansible.builtin.uri:
+        url: "https://{{ inventory.get('remote_webserver', ansible_fqdn) }}{{ inventory.app_context }}"
+        validate_certs: false
+
+- name: Re-enabling PIH user access
+  ansible.builtin.import_playbook: ../playbooks/enable_pih_user_access.yml

--- a/ansible/inventories/pih_azure.yml
+++ b/ansible/inventories/pih_azure.yml
@@ -34,3 +34,13 @@ all:
           ansible_host: 10.160.28.17
           inventory:
             db_name: openboxes
+dbservers:
+  children:
+    dev:
+    stg:
+    prd:
+webservers:
+  children:
+    dev:
+    stg:
+    prd:

--- a/ansible/inventories/pih_rimu.yml
+++ b/ansible/inventories/pih_rimu.yml
@@ -195,3 +195,11 @@ all:
       hosts:
         obstg:
         dbstg:
+    dbservers:
+      children:
+        big_dbservers:
+        dev:
+    webservers:
+      children:
+        big_webservers:
+        dev:

--- a/ansible/scripts/reset_db.bash
+++ b/ansible/scripts/reset_db.bash
@@ -5,10 +5,11 @@ usage()
 {
     echo >&2 "$0 - reset/recreate an OpenBoxes database"
     echo >&2 ''
-    echo >&2 "Usage: $0 [-s] [-d <db_name>] [-p <mysql_path> ] [-u <db_user> ]"
+    echo >&2 "Usage: $0 [-s] [-c <host_name>] [-d <db_name>] [-p <mysql_path> ] [-u <db_user> ]"
     echo >&2 ''
     echo >&2 'Options:'
     echo >&2 '  -s use sudo when accessing db server (if using auth_socket for root)'
+    echo >&2 '  -c <host_name> -- name of host from which to allow client access (default: "localhost")'
     echo >&2 '  -d <db_name> -- name of database to reset/recreate (default: "openboxes")'
     echo >&2 '  -p <mysql_path> -- path under which mysql is installed'
     echo >&2 '  -u <db_user> -- name of database user (default: "openboxes")'
@@ -16,14 +17,19 @@ usage()
     [ "$@" ] && exit "$@" || exit 2
 }
 
+db_client='localhost'
 db_name='openboxes'
 db_user='openboxes'
 local_sudo=
 mysql_path=/usr/bin:/usr/local/mysql/bin
 
-while getopts 'd:hp:su:' o
+while getopts 'c:d:hp:su:' o
 do
     case "$o" in
+    c)
+        [ "$OPTARG" ] || usage
+        db_client="$OPTARG"
+        ;;
     d)
         [ "$OPTARG" ] || usage
         db_name="$OPTARG"
@@ -68,8 +74,11 @@ $local_sudo true
 
 echo "(Re)initializing database \`$db_name\` ..."
 $local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "drop database if exists \`$db_name\`;"
-$local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "create user if not exists '$db_user'@'localhost'; alter user '$db_user'@'localhost' identified by '$DB_USER_PASSWORD'; flush privileges;"
-$local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "create database \`$db_name\` default charset utf8; grant all on \`$db_name\`.* to '$db_user'@'localhost';"
-$local_sudo mysql -u "$db_user" -p"$DB_USER_PASSWORD" "$db_name" -e 'select 1' > /dev/null
-
+$local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "drop user if exists '$db_user'@'$db_client'; create user '$db_user'@'$db_client' identified by '$DB_USER_PASSWORD'; flush privileges;"
+$local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "create database \`$db_name\` default charset utf8; grant all on \`$db_name\`.* to '$db_user'@'$db_client';"
+$local_sudo mysql -u root -p"$DB_ROOT_PASSWORD" -e "delete from mysql.user where User = 'finance';"
+if [ "$db_client" == 'localhost' ]
+then
+    $local_sudo mysql -u "$db_user" -p"$DB_USER_PASSWORD" "$db_name" -e 'select 1' > /dev/null
+fi
 echo 'Done'


### PR DESCRIPTION
Hi folks, this PR updates `reset_db.yml` and `restore_db.yml` so that they work as expected on split hosts like `dbstg`/`obstg`. Targets for these runbooks should be `stg` or `prd` because in both cases, when the DB is replaced, Tomcat needs to be restarted to kick off the liquibase migrations.

These scripts poll the affected services after kicking them and report if they don't come back up cleanly.