### PR TITLE
OBS-1465 Support additional hostnames for certbot certificates

### DIFF
--- a/ansible/inventories/pih_rimu.yml
+++ b/ansible/inventories/pih_rimu.yml
@@ -54,11 +54,16 @@ all:
           ansible_host: 74.50.49.135
           inventory:
             <<: *big_webserver_inventory
+            additional_domains:
+              - obnav.pih-emr.org
+              - openboxes.pih-emr.org
             db_url: jdbc:mysql://dbprd.pih-emr.org:3306/openboxes
         obstg:
           ansible_host: 74.50.49.133
           inventory:
             <<: *big_webserver_inventory
+            additional_domains:
+              - obnavstage.pih-emr.org
             db_url: jdbc:mysql://dbstg.pih-emr.org:3306/openboxes
 
     big_dbservers:

--- a/ansible/playbooks/install_requirements.yml
+++ b/ansible/playbooks/install_requirements.yml
@@ -373,7 +373,9 @@
           ansible.builtin.command:
             cmd: >
               /snap/bin/certbot -m {{ inventory.mail.sender }} -nv --agree-tos
-              --domains {{ ansible_fqdn }} --must-staple --nginx --redirect --staple-ocsp
+              --domains {{ domains }} --expand --must-staple --nginx --redirect --staple-ocsp
+          vars:
+            domains: "{{ ([ansible_fqdn] + inventory.get('additional_domains', [])) | join(',') }}"
 
         - name: Collecting Certbot output
           when: certbot.stdout_lines is defined

--- a/ansible/templates/default.conf.j2
+++ b/ansible/templates/default.conf.j2
@@ -60,7 +60,7 @@ server {
 
     resolver 1.1.1.1 1.0.0.1 valid=300s;
     resolver_timeout 3s;
-    server_name {{ ansible_fqdn }};
+    server_name {{ ([ansible_fqdn] + inventory.get('additional_domains', [])) | join(' ') }};
 
     location /images {
         root /etc/nginx/static;


### PR DESCRIPTION
This will allow e.g. obprd to present valid certificates for openboxes.pih-emr.org and obnav.pih-emr.org when the time comes.