### PR TITLE
OBS-1504 Enable fail2ban for ssh and mysql (with limited nginx support)

### DIFF
--- a/ansible/playbooks/security.yml
+++ b/ansible/playbooks/security.yml
@@ -53,3 +53,34 @@
         logging: 'on'
         policy: reject
         state: enabled
+
+    - name: Creating mysql log directory if not present
+      ansible.builtin.file:
+        group: mysql
+        mode: 'u+rwx,g+rs'
+        owner: mysql
+        path: /var/log/mysql
+        state: directory
+
+    - name: Touching mysql error file (fail2ban will not start without it)
+      ansible.builtin.file:
+        group: mysql
+        mode: '0660'
+        owner: mysql
+        path: /var/log/mysql/error.log
+        state: touch
+
+    - name: Configuring fail2ban protection
+      ansible.builtin.template:
+        dest: /etc/fail2ban/jail.local
+        group: root
+        mode: '0444'
+        owner: root
+        src: ../templates/jail.local.j2
+
+    - name: Starting fail2ban
+      ansible.builtin.systemd:
+        daemon_reload: true
+        enabled: true
+        name: fail2ban
+        state: restarted

--- a/ansible/templates/jail.local.j2
+++ b/ansible/templates/jail.local.j2
@@ -1,0 +1,29 @@
+# Ansible generated this file from {{ template_path }}; do not edit locally!
+{# If this comment is present, this is the template file: disregard this warning #}
+
+{% if inventory.get('mysql', {}).get('enabled') %}
+[mysqld-auth]
+enabled = true
+logpath = /var/log/mysql/error.log
+{% endif %}
+
+{% if inventory.get('tomcat', {}).get('enabled') %}
+#
+# This module won't help us much out of the box, because Openboxes responds to
+# login failures with a 302 Found, not, e.g., 403. So to really get this working
+# the way it should, we should have add some regular expressions here to search
+# for 302 redirects like this:
+# >
+# > 98.247.183.173 - - [13/Jun/2023:20:04:07 +0000] "POST /openboxes/auth/handleLogin HTTP/2.0"
+# > 302 0 "https://obdev3.pih-emr.org/openboxes/auth/login"
+# > "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15"
+# >
+# In addition, we may want to consider nginx-limit-req. It is well-documented;
+# see: http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+#
+[nginx-http-auth]
+enabled = true
+{% endif %}
+
+[sshd]
+enabled = true


### PR DESCRIPTION
Fail2ban is a tool that inspects log files and dynamically updates `ufw` to temporarily block mischief-makers. It has a number of plugins; I've enabled ones for `ssh`, `mysql` and `nginx`. Unfortunately, Openboxes responds to login failures with a 302 redirect instead of a 403, which I think is what fail2ban looks for by default. I've added comments to the config file to that effect.

That being said, these changes should still protect ssh and mysql from a particular flavor of bad actor.