### PR TITLE
move new BIS host under proper category

### DIFF
--- a/ansible/inventories/pih_rimu.yml
+++ b/ansible/inventories/pih_rimu.yml
@@ -145,6 +145,7 @@ all:
             pih_cld_whdev:
               ips:
                 - 40.70.215.46
+                - 208.89.61.42
               mysql_user: finance
               port: 3306
               require_mysql_ssl: false
@@ -158,7 +159,6 @@ all:
               ips:
                 - 44.231.117.185
                 - 52.89.22.131
-                - 208.89.61.42
               mysql_user: finance
               port: 3306
               require_mysql_ssl: true


### PR DESCRIPTION
@awalkowiak turns out the correct place to put the ip was under pih_cld_whdev. I'll merge this once I get confirmation from IT but wanted to loop you in in case you were curious.

For future reference (and in hindsight it's incredibly obvious), the block we add the host to depends on the environment the connection is coming from:
- pih_cld_whdev: the WHDEV environment
- pih_cld_whprod: the WHPROD environment
- rapidi: for the rapidi integration (dev and prod). Is an external env so we have additional security requirements for any hosts added here